### PR TITLE
Remove space for GitHub when not provided

### DIFF
--- a/exampleSite/README.md
+++ b/exampleSite/README.md
@@ -1,4 +1,5 @@
 [![License: CC BY 4.0](https://img.shields.io/badge/License-CC%20BY%204.0-lightgrey.svg)](https://creativecommons.org/licenses/by/4.0/)
+
 # Portfolio Website
 
-This is the content of my personal website hosted at [samrobbins.uk](https://samrobbins.uk). The theme which I have made is stored in a separate github repository [hugo-developer-portfolio](https://github.com/samrobbins85/hugo-developer-portfolio). 
+This is an example Site, made to work specifically when inside the theme. If you want this to work, you need to remove the lines in `config.toml` under "Remove this when using normally" and instead uncomment the lines below that.

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -2,15 +2,15 @@
 baseURL = "https://example.com"
 languageCode = "en-gb"
 title = "Sam Robbins"
-# theme = "hugo-developer-portfolio"
 googleAnalytics = ""
 
 # Remove this when using normally
-# themesDir = "../../" 
-# `
-[module]
-  [[module.imports]]
-    path = "github.com/samrobbins85/hugo-developer-portfolio"
+themesDir = "../../" 
+theme = "hugo-developer-portfolio"
+# 
+#[module]
+#  [[module.imports]]
+#    path = "github.com/samrobbins85/hugo-developer-portfolio"
 
 # Plugins
 [params.plugins]

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -5,8 +5,8 @@ title = "Sam Robbins"
 googleAnalytics = ""
 
 # Remove this when using normally
-themesDir = "../../" 
-theme = "hugo-developer-portfolio"
+themesDir = "../" 
+theme = "."
 # 
 #[module]
 #  [[module.imports]]

--- a/exampleSite/content/portfolio/example-team-no-github.md
+++ b/exampleSite/content/portfolio/example-team-no-github.md
@@ -1,0 +1,15 @@
++++
+categories = ["web-dev"]
+coders = ["samrobbins85", "Gorgeous-Patrick"]
+date = 2020-06-19T23:00:00Z
+description = "A portfolio website made with Hugo"
+image = "https://res.cloudinary.com/samrobbins/image/upload/q_auto/v1591793276/logos/logos_hugo_h2xbne.svg"
+title = "Team project without GitHub"
+type = "post"
+[[tech]]
+logo = "https://res.cloudinary.com/samrobbins/image/upload/v1591793276/logos/logos_hugo_h2xbne.svg"
+name = "Hugo"
+url = "https://gohugo.io/"
++++
+
+This is some content

--- a/exampleSite/vercel.json
+++ b/exampleSite/vercel.json
@@ -1,8 +1,7 @@
 {
   "build": {
     "env": {
-      "HUGO_VERSION": "0.71.0"
+      "HUGO_VERSION": "0.98.0"
     }
   }
 }
- 

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -121,7 +121,7 @@
     {{end}}
 
 
-
+    {{if isset .Params "github"}}
       <div>
         {{if ( gt (len .Params.github ) 1)}}
         <div>
@@ -144,7 +144,9 @@
           Github</a>
         {{end}}
       </div>
+      {{end}}
     </div>
+
     {{end}}
 
     <hr class="full-width">


### PR DESCRIPTION
Fixes #19, checks if GitHub is set, and if not won't show the wrapping div which was causing a gap to be presented where the GitHub button would otherwise be

Adds an example of correct functionality